### PR TITLE
fixed SL_FOREACH_SAFE

### DIFF
--- a/src/list.h
+++ b/src/list.h
@@ -108,7 +108,7 @@
 	for(node = head; node; node = node->next)
 
 #define SL_FOREACH_SAFE(head, node, tmp) \
-	for (node = head, tmp = node->next; node; node = tmp)
+	for (node = head, tmp = node->next; node; node = tmp, tmp = node->next)
 
 #define SL_INDEX(head, node, target) do { \
 	int _i = target; \


### PR DESCRIPTION
The SL_FOREACH_SAFE function can result in a endless loop. The tmp pointer is not updated to the next in the list. 

